### PR TITLE
Add Ascraeus NixOS-anywhere deployment profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+deployment/secrets.env
+deployment/generated/
+deployment/runtime/
+result
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
 # nixos-anywhere-ascraeus
+
+This repository contains a complete NixOS configuration and deployment tooling
+for provisioning the **Ascraeus** desktop using
+[`nixos-anywhere`](https://github.com/nix-community/nixos-anywhere).
+
+## Target hardware layout
+
+* UEFI `/boot` partition on **/dev/sdc** (16&nbsp;GiB USB flash media)
+* Encrypted root volume on **/dev/sda** (1&nbsp;TiB SATA SSD) using LUKS on LVM with an ext4 filesystem
+* AMD CPU microcode updates and NVIDIA proprietary drivers
+* KDE Plasma 6 desktop environment with SDDM login manager
+
+Disk provisioning is handled through the `disko` module. `/dev/sdc` is prepared
+as a GPT disk with a single EFI system partition formatted as FAT32. `/dev/sda`
+becomes a single GPT partition encrypted with LUKS, providing the `vg0` volume
+group. Two logical volumes are created: `root` (ext4, mounted at `/`) and `swap`
+(16&nbsp;GiB).
+
+## Repository layout
+
+```
+.
+├── deployment            # Deployment tooling and defaults
+│   ├── deploy.sh         # Interactive deployment helper
+│   ├── defaults          # Default data used by the configuration
+│   └── secrets.env.example
+├── hosts                 # Host specific configuration split into small modules
+│   ├── ascraeus          # Ascraeus desktop configuration
+│   └── common            # Reusable building blocks
+└── flake.nix             # Entry point for nixos-anywhere
+```
+
+Every configuration area is split into a focused module to keep files small and
+readable. Host specific overrides live under `hosts/ascraeus/` while shared
+settings live under `hosts/common/`.
+
+## Prerequisites
+
+* A NixOS machine acting as the deployment controller (run all commands as
+  `root`)
+* Network access to the target NixOS live ISO (`root@<ip>`)
+* `git` and `nixos-anywhere` available locally (included in the dev shell)
+
+To enter a development shell with the required tooling, run:
+
+```bash
+nix develop
+```
+
+## Preparing secrets
+
+Copy the example secrets file and edit the defaults to suit your environment.
+This file is never committed to git.
+
+```bash
+cp deployment/secrets.env.example deployment/secrets.env
+$EDITOR deployment/secrets.env
+```
+
+## Running a deployment
+
+1. Boot the target machine with the NixOS live ISO and ensure SSH access as the
+   `root` user.
+2. Connect the USB drive that will host `/boot` as `/dev/sdc`.
+3. From the controller machine, execute:
+
+   ```bash
+   ./deployment/deploy.sh
+   ```
+
+4. Answer the prompts for the target host, user credentials, and encryption
+   passphrase. Defaults are loaded from `deployment/secrets.env` when present.
+5. The script will generate the required user data, securely stage the LUKS
+   passphrase on the live system, and then run `nixos-anywhere` with the
+   `ascraeus` configuration.
+
+Upon completion the system reboots into the freshly installed NixOS desktop.
+Change the default passwords immediately after first boot if you used the
+example values.
+
+## Updating configuration
+
+Modify the relevant module under `hosts/ascraeus/` or extend the shared modules
+under `hosts/common/`. Keep changes small and targeted to preserve readability.
+
+After making changes you can redeploy using the same `deployment/deploy.sh`
+script. The generated secrets are refreshed on each run.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,10 @@
+# Deployment helper
+
+`deploy.sh` orchestrates an unattended install by collecting credentials,
+staging the LUKS passphrase on the target, and invoking `nixos-anywhere` with
+the `ascraeus` configuration. Defaults are sourced from `secrets.env` when it
+exists; copy `secrets.env.example` to get started.
+
+Generated user data lives in `deployment/generated/user.nix` (ignored by git).
+Transient secrets such as the LUKS passphrase are placed under
+`deployment/runtime/` and cleaned up automatically after each run.

--- a/deployment/defaults/user.nix
+++ b/deployment/defaults/user.nix
@@ -1,0 +1,6 @@
+{
+  username = "orion";
+  fullName = "Primary User";
+  hashedPassword = "$6$VawCH3e0m79LzbG5$jX/IgxuSEeRbQZKet4Xz5a1LtE0rmPmipeU6lnwEjV0x4lR2O9BH7GCC2tMO/brsQY1J7x4i7x.pJa6eATsEz0";
+  rootHashedPassword = "$6$VawCH3e0m79LzbG5$jX/IgxuSEeRbQZKet4Xz5a1LtE0rmPmipeU6lnwEjV0x4lR2O9BH7GCC2tMO/brsQY1J7x4i7x.pJa6eATsEz0";
+}

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+DEFAULTS_FILE="${SCRIPT_DIR}/secrets.env"
+GENERATED_DIR="${SCRIPT_DIR}/generated"
+RUNTIME_DIR="${SCRIPT_DIR}/runtime"
+USER_FILE="${GENERATED_DIR}/user.nix"
+LUKS_FILE="${RUNTIME_DIR}/luks-passphrase"
+
+mkdir -p "${GENERATED_DIR}" "${RUNTIME_DIR}"
+chmod 700 "${GENERATED_DIR}" "${RUNTIME_DIR}"
+
+cleanup() {
+  rm -f "${LUKS_FILE}"
+}
+trap cleanup EXIT
+
+if [[ -f "${DEFAULTS_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${DEFAULTS_FILE}"
+fi
+
+prompt_with_default() {
+  local prompt="$1"
+  local default="$2"
+  local value
+  if [[ -n "${default}" ]]; then
+    read -r -p "${prompt} [${default}]: " value
+    if [[ -z "${value}" ]]; then
+      value="${default}"
+    fi
+  else
+    read -r -p "${prompt}: " value
+  fi
+  echo "${value}"
+}
+
+read_secret() {
+  local prompt="$1"
+  local default="$2"
+  local value
+  if [[ -n "${default}" ]]; then
+    read -r -s -p "${prompt} [press enter to keep default]: " value
+    echo
+    if [[ -z "${value}" ]]; then
+      value="${default}"
+    fi
+  else
+    read -r -s -p "${prompt}: " value
+    echo
+  fi
+  echo "${value}"
+}
+
+hash_password() {
+  local password="$1"
+  if command -v openssl >/dev/null 2>&1; then
+    openssl passwd -6 "${password}"
+  else
+    nix shell --inputs-from "${REPO_ROOT}" nixpkgs#openssl --command openssl passwd -6 "${password}"
+  fi
+}
+
+escape_nix_string() {
+  local input="$1"
+  printf '%s' "${input}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+target_host=$(prompt_with_default "Target host (user@host)" "${DEPLOY_TARGET_HOST:-root@192.168.1.50}")
+ssh_port=$(prompt_with_default "SSH port" "${DEPLOY_SSH_PORT:-22}")
+username=$(prompt_with_default "Primary username" "${DEPLOY_USERNAME:-orion}")
+full_name=$(prompt_with_default "Full name" "${DEPLOY_FULL_NAME:-Primary User}")
+user_password=$(read_secret "Password for ${username}" "${DEPLOY_USER_PASSWORD:-}")
+root_default="${DEPLOY_ROOT_PASSWORD:-${user_password}}"
+root_password=$(read_secret "Root password" "${root_default}")
+encryption_passphrase=$(read_secret "LUKS encryption passphrase" "${DEPLOY_LUKS_PASSPHRASE:-}")
+
+if [[ -z "${encryption_passphrase}" ]]; then
+  echo "Encryption passphrase is required." >&2
+  exit 1
+fi
+
+user_hash=$(hash_password "${user_password}")
+root_hash=$(hash_password "${root_password}")
+
+escaped_username=$(escape_nix_string "${username}")
+escaped_full_name=$(escape_nix_string "${full_name}")
+escaped_user_hash=$(escape_nix_string "${user_hash}")
+escaped_root_hash=$(escape_nix_string "${root_hash}")
+
+cat > "${USER_FILE}" <<USER_CFG
+{
+  username = "${escaped_username}";
+  fullName = "${escaped_full_name}";
+  hashedPassword = "${escaped_user_hash}";
+  rootHashedPassword = "${escaped_root_hash}";
+}
+USER_CFG
+chmod 600 "${USER_FILE}"
+
+echo "${encryption_passphrase}" > "${LUKS_FILE}"
+chmod 600 "${LUKS_FILE}"
+
+scp -P "${ssh_port}" "${LUKS_FILE}" "${target_host}:/tmp/luks-passphrase"
+ssh -p "${ssh_port}" "${target_host}" 'chmod 600 /tmp/luks-passphrase'
+
+install_cmd=(
+  nixos-anywhere
+  --flake "${REPO_ROOT}#ascraeus"
+  --ssh-port "${ssh_port}"
+  "${target_host}"
+)
+
+echo "Starting deployment with nixos-anywhere..."
+"${install_cmd[@]}"
+
+ssh -p "${ssh_port}" "${target_host}" 'rm -f /tmp/luks-passphrase' || true
+
+echo "Deployment completed."

--- a/deployment/secrets.env.example
+++ b/deployment/secrets.env.example
@@ -1,0 +1,10 @@
+# Copy this file to secrets.env and adjust the defaults for your environment.
+# The deployment script will source secrets.env when present.
+
+DEPLOY_TARGET_HOST="root@192.168.1.50"
+DEPLOY_SSH_PORT="22"
+DEPLOY_USERNAME="orion"
+DEPLOY_FULL_NAME="Primary User"
+DEPLOY_USER_PASSWORD="changeme"
+DEPLOY_ROOT_PASSWORD="changeme"
+DEPLOY_LUKS_PASSPHRASE="nixos-anywhere"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "NixOS-anywhere deployment for the Ascraeus desktop";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    disko.url = "github:nix-community/disko";
+    nixos-anywhere.url = "github:nix-community/nixos-anywhere";
+  };
+
+  outputs = inputs@{ self, nixpkgs, disko, nixos-anywhere, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      nixosConfigurations.ascraeus = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./hosts/ascraeus
+          disko.nixosModules.disko
+          { nixpkgs.hostPlatform = system; }
+        ];
+      };
+
+      formatter.${system} = pkgs.nixpkgs-fmt;
+
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [
+          pkgs.git
+          nixos-anywhere.packages.${system}.default
+          disko.packages.${system}.disko
+        ];
+      };
+    };
+}

--- a/hosts/ascraeus/README.md
+++ b/hosts/ascraeus/README.md
@@ -1,0 +1,13 @@
+# Ascraeus desktop profile
+
+The Ascraeus profile assembles the shared modules with hardware specific
+settings for the AMD/NVIDIA workstation targeted by this project. Files are
+kept small and purposeful:
+
+* `hardware.nix` — firmware, bootloader and GPU drivers
+* `storage.nix` — disko layout for /dev/sdc (boot) and /dev/sda (LUKS/LVM root)
+* `networking.nix` — hostname, firewall, and SSH policy
+* `desktop.nix` — KDE Plasma 6 desktop stack
+* `users.nix` — immutable user definitions sourced from generated secrets
+* `services.nix` — supporting services and packages
+* `performance.nix` — tuned kernel and power-management defaults

--- a/hosts/ascraeus/default.nix
+++ b/hosts/ascraeus/default.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+{
+  imports = [
+    ../common/base.nix
+    ./hardware.nix
+    ./storage.nix
+    ./networking.nix
+    ./desktop.nix
+    ./users.nix
+    ./services.nix
+    ./performance.nix
+  ];
+
+  system.stateVersion = lib.mkDefault "23.11";
+}

--- a/hosts/ascraeus/desktop.nix
+++ b/hosts/ascraeus/desktop.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+{
+  services.xserver = {
+    enable = true;
+    layout = "us";
+    libinput.enable = true;
+    desktopManager.plasma6.enable = true;
+    displayManager.sddm.enable = true;
+  };
+
+  hardware.pulseaudio.enable = false;
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+    jack.enable = true;
+  };
+
+  programs = {
+    kdeconnect.enable = true;
+    firefox.enable = true;
+  };
+
+  environment.systemPackages = with pkgs; [
+    kate
+    kdePackages.konsole
+  ];
+}

--- a/hosts/ascraeus/hardware.nix
+++ b/hosts/ascraeus/hardware.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+{
+  boot = {
+    loader = {
+      systemd-boot.enable = true;
+      efi = {
+        canTouchEfiVariables = true;
+      };
+    };
+    initrd = {
+      availableKernelModules = [ "xhci_pci" "ahci" "nvme" "usbhid" "sd_mod" ];
+      luks.devices.cryptroot = {
+        device = "/dev/disk/by-partlabel/cryptroot";
+        preLVM = true;
+        allowDiscards = true;
+      };
+    };
+    kernelModules = [ "kvm-amd" ];
+    extraModulePackages = [];
+  };
+
+  hardware = {
+    cpu.amd.updateMicrocode = lib.mkDefault true;
+    opengl = {
+      enable = true;
+      driSupport = true;
+      driSupport32Bit = true;
+    };
+    nvidia = {
+      modesetting.enable = true;
+      powerManagement.enable = true;
+      powerManagement.finegrained = true;
+      nvidiaSettings = true;
+      package = config.boot.kernelPackages.nvidiaPackages.production;
+    };
+  };
+
+  services.xserver.videoDrivers = [ "nvidia" ];
+}

--- a/hosts/ascraeus/networking.nix
+++ b/hosts/ascraeus/networking.nix
@@ -1,0 +1,21 @@
+{ ... }:
+{
+  networking = {
+    hostName = "ascraeus";
+    firewall = {
+      enable = true;
+      allowPing = true;
+      allowedTCPPorts = [ 22 80 443 ];
+    };
+    networkmanager.enable = true;
+  };
+
+  services.openssh = {
+    enable = true;
+    settings = {
+      PasswordAuthentication = true;
+      KbdInteractiveAuthentication = false;
+      PermitRootLogin = "prohibit-password";
+    };
+  };
+}

--- a/hosts/ascraeus/performance.nix
+++ b/hosts/ascraeus/performance.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+{
+  boot.kernel.sysctl = {
+    "vm.swappiness" = 10;
+    "vm.dirty_ratio" = 10;
+    "vm.dirty_background_ratio" = 5;
+  };
+
+  services.thermald.enable = lib.mkDefault true;
+
+  powerManagement = {
+    enable = true;
+    cpuFreqGovernor = lib.mkDefault "schedutil";
+  };
+
+  services.fstrim.enable = true;
+}

--- a/hosts/ascraeus/services.nix
+++ b/hosts/ascraeus/services.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+{
+  services.printing.enable = true;
+  services.blueman.enable = true;
+
+  hardware.bluetooth.enable = true;
+
+  services.flatpak.enable = true;
+
+  systemd.services.nix-daemon.serviceConfig.LimitNOFILE = 1048576;
+
+  environment.systemPackages = with pkgs; [
+    htop
+    nvtopPackages.full
+  ];
+}

--- a/hosts/ascraeus/storage.nix
+++ b/hosts/ascraeus/storage.nix
@@ -1,0 +1,88 @@
+{ ... }:
+{
+  disko.devices = {
+    disk = {
+      boot = {
+        type = "disk";
+        device = "/dev/sdc";
+        content = {
+          type = "gpt";
+          partitions.EFI = {
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "defaults" "noatime" ];
+              label = "BOOT";
+            };
+          };
+        };
+      };
+      primary = {
+        type = "disk";
+        device = "/dev/sda";
+        content = {
+          type = "gpt";
+          partitions.cryptroot = {
+            size = "100%";
+            type = "8300";
+            content = {
+              type = "luks";
+              name = "cryptroot";
+              settings.allowDiscards = true;
+              passwordFile = "/tmp/luks-passphrase";
+              content = {
+                type = "lvm_pv";
+                volumeGroup = "vg0";
+              };
+            };
+          };
+        };
+      };
+    };
+
+    lvm_vg.vg0 = {
+      type = "lvm_vg";
+      physicalVolumes = [ "/dev/mapper/cryptroot" ];
+      lvs = {
+        root = {
+          size = "100%FREE";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+            label = "nixos-root";
+            mountOptions = [ "noatime" "discard" ];
+          };
+        };
+        swap = {
+          size = "16G";
+          content = {
+            type = "swap";
+            resumeDevice = true;
+            label = "SWAP";
+          };
+        };
+      };
+    };
+  };
+
+  fileSystems = {
+    "/" = {
+      device = "/dev/disk/by-label/nixos-root";
+      fsType = "ext4";
+      options = [ "noatime" "discard" ];
+    };
+    "/boot" = {
+      device = "/dev/disk/by-label/BOOT";
+      fsType = "vfat";
+      options = [ "noatime" ];
+    };
+  };
+
+  swapDevices = [
+    { device = "/dev/disk/by-label/SWAP"; }
+  ];
+}

--- a/hosts/ascraeus/users.nix
+++ b/hosts/ascraeus/users.nix
@@ -1,0 +1,33 @@
+{ config, ... }:
+let
+  defaultUserPath = ../../deployment/defaults/user.nix;
+  generatedUserPath = ../../deployment/generated/user.nix;
+  userData = if builtins.pathExists generatedUserPath then import generatedUserPath else import defaultUserPath;
+  username = userData.username;
+  fullName = userData.fullName or username;
+  hashedPassword = userData.hashedPassword;
+  rootHashedPassword = userData.rootHashedPassword or hashedPassword;
+  extraGroups = [ "wheel" "networkmanager" "video" "audio" ];
+  ensurePassword = value: if value == null then "!" else value;
+  userEntry = {
+    isNormalUser = true;
+    description = fullName;
+    inherit extraGroups;
+    hashedPassword = ensurePassword hashedPassword;
+    shell = config.users.defaultUserShell;
+  };
+in
+{
+  users.mutableUsers = false;
+  users.users = {
+    "${username}" = userEntry;
+    root = {
+      hashedPassword = ensurePassword rootHashedPassword;
+    };
+  };
+
+  security.sudo = {
+    enable = true;
+    wheelNeedsPassword = false;
+  };
+}

--- a/hosts/common/README.md
+++ b/hosts/common/README.md
@@ -1,0 +1,5 @@
+# Common host modules
+
+Shared modules keep the configuration modular and easy to audit. Each file in
+this directory focuses on a single area (locale, nix settings, shell defaults)
+and is imported by host configurations as needed.

--- a/hosts/common/base.nix
+++ b/hosts/common/base.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+{
+  imports = [
+    ./localisation.nix
+    ./nix.nix
+    ./shell.nix
+  ];
+
+  time.timeZone = "UTC";
+  networking.useDHCP = lib.mkDefault true;
+}

--- a/hosts/common/localisation.nix
+++ b/hosts/common/localisation.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  i18n.defaultLocale = "en_US.UTF-8";
+  console = {
+    font = "Lat2-Terminus16";
+    keyMap = "us";
+  };
+}

--- a/hosts/common/nix.nix
+++ b/hosts/common/nix.nix
@@ -1,0 +1,9 @@
+{ ... }:
+{
+  nix.settings = {
+    experimental-features = [ "nix-command" "flakes" ];
+    auto-optimise-store = true;
+  };
+
+  nixpkgs.config.allowUnfree = true;
+}

--- a/hosts/common/shell.nix
+++ b/hosts/common/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+{
+  environment.systemPackages = with pkgs; [
+    git
+    wget
+    vim
+  ];
+
+  programs.zsh.enable = true;
+  users.defaultUserShell = pkgs.zsh;
+}


### PR DESCRIPTION
## Summary
- add a flake-based Ascraeus host definition composed of small modules for hardware, storage, desktop, networking, services, and performance tuning
- provide deployment tooling with defaults, secrets management, and interactive prompts to drive nixos-anywhere
- document the repository layout and deployment workflow for the targeted AMD/NVIDIA workstation

## Testing
- bash -n deployment/deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3f3b309d4833181541c15f9b39e12