### PR TITLE
Fix LVM configuration for disko

### DIFF
--- a/hosts/ascraeus/storage.nix
+++ b/hosts/ascraeus/storage.nix
@@ -35,7 +35,7 @@
               passwordFile = "/tmp/luks-passphrase";
               content = {
                 type = "lvm_pv";
-                volumeGroup = "vg0";
+                vg = "vg0";
               };
             };
           };
@@ -45,7 +45,6 @@
 
     lvm_vg.vg0 = {
       type = "lvm_vg";
-      physicalVolumes = [ "/dev/mapper/cryptroot" ];
       lvs = {
         root = {
           size = "100%FREE";


### PR DESCRIPTION
## Summary
- update the LUKS volume definition to use the current disko lvm_pv attribute
- rely on disko's automatic LVM physical volume detection instead of hard-coding paths

## Testing
- not run (nix is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e41af0108c8331b2d11979307faad9