### PR TITLE
Configure nix-community Cachix cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ settings live under `hosts/common/`.
 * Network access to the target NixOS live ISO (`root@<ip>`)
 * `git` and `nixos-anywhere` available locally (included in the dev shell)
 
+## Faster builds with Cachix
+
+The flake and system configuration trust the public
+[`nix-community`](https://nix-community.cachix.org) Cachix binary cache. This
+allows both local builds and remote deployments to reuse pre-built derivations,
+significantly cutting down the time spent compiling packages. The development
+shell also ships with the `cachix` CLI should you need to inspect or warm the
+cache manually.
+
 To enter a development shell with the required tooling, run:
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "NixOS-anywhere deployment for the Ascraeus desktop";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     disko.url = "github:nix-community/disko";
@@ -26,6 +35,7 @@
       devShells.${system}.default = pkgs.mkShell {
         packages = [
           pkgs.git
+          pkgs.cachix
           nixos-anywhere.packages.${system}.default
           disko.packages.${system}.disko
         ];

--- a/hosts/common/nix.nix
+++ b/hosts/common/nix.nix
@@ -1,8 +1,14 @@
-{ ... }:
+{ lib, ... }:
 {
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
     auto-optimise-store = true;
+    substituters = lib.mkBefore [
+      "https://nix-community.cachix.org"
+    ];
+    trusted-public-keys = lib.mkBefore [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
   };
 
   nixpkgs.config.allowUnfree = true;


### PR DESCRIPTION
## Summary
- configure the flake to trust the public nix-community Cachix binary cache
- ensure the system configuration and dev shell inherit the same cache and tooling
- document the faster Cachix-backed workflow in the README

## Testing
- not run (nix unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e42bf532808331a7f0a36f094b57a5